### PR TITLE
#4 OAuth2 option: add optional client secret

### DIFF
--- a/src/agent/client/oauth2.rs
+++ b/src/agent/client/oauth2.rs
@@ -7,6 +7,7 @@ use crate::{
     config::oauth2,
     context::OAuth2Context,
 };
+use ::oauth2::ClientSecret;
 use ::oauth2::{
     basic::{BasicClient, BasicTokenResponse},
     reqwest::async_http_client,
@@ -50,7 +51,7 @@ impl Client for OAuth2Client {
     async fn from_config(config: Self::Configuration) -> Result<Self, OAuth2Error> {
         let client = BasicClient::new(
             ClientId::new(config.client_id),
-            None,
+            config.client_secret.map(|secret| ClientSecret::new(secret)),
             AuthUrl::new(config.auth_url)
                 .map_err(|err| OAuth2Error::Configuration(format!("invalid auth URL: {err}")))?,
             Some(

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub mod openid {
         #[serde(default)]
         /// Additional, non-required configuration, with a default.
         pub additional: Additional,
+
     }
 
     #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,14 +39,16 @@ pub mod oauth2 {
         pub client_id: String,
         pub auth_url: String,
         pub token_url: String,
+        pub client_secret: Option<String>
     }
 
     impl Config {
-        pub fn new<C, A, T, S, I>(client_id: C, auth_url: A, token_url: T) -> Self
+        pub fn new<C, A, T,O, S, I>(client_id: C, auth_url: A, token_url: T, client_secret: O) -> Self
         where
             C: Into<String>,
             A: Into<String>,
             T: Into<String>,
+            O: Into<Option<String>>,
             S: IntoIterator<Item = I>,
             I: Into<String>,
         {
@@ -53,6 +56,7 @@ pub mod oauth2 {
                 client_id: client_id.into(),
                 auth_url: auth_url.into(),
                 token_url: token_url.into(),
+                client_secret: client_secret.into()
             }
         }
     }


### PR DESCRIPTION
Closes #4

OAuth2 providers like google require client_secret.

Test:

![Jul-22-2022 22-15-54](https://user-images.githubusercontent.com/1176339/180586757-0f23d1b4-c0a6-4e0e-bab7-988fe3d1d865.gif)

