### PR TITLE
feat: migrate to Yew 0.20, using yew-nested-router in the process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,12 +22,12 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: wasm32-unknown-unknown
-          override: true
-          components: rustfmt, clippy
+
+      - name: Install Rust ${{ matrix.toolchain }}
+        run: |
+          rustup toolchain install ${{ matrix.toolchain }}
+          rustup default ${{ matrix.toolchain }}
+          rustup target add wasm32-unknown-unknown
 
       - uses: actions/cache@v3
         with:
@@ -40,30 +40,21 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          cargo fmt --all -- --check
 
       - name: Install cargo check-all
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-all-features --force
+        run: |
+          cargo install cargo-all-features --force
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check-all-features
-          args: --target wasm32-unknown-unknown
+        run: |
+          cargo check-all-features --target wasm32-unknown-unknown
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test-all-features
+        run: |
+          cargo test-all-features
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --target wasm32-unknown-unknown -- -D warnings
+        run: |
+          cargo clippy --target wasm32-unknown-unknown -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,8 @@ jobs:
 
       - name: Install Rust ${{ matrix.toolchain }}
         run: |
-          rustup toolchain install ${{ matrix.toolchain }}
+          rustup toolchain install ${{ matrix.toolchain }} --components rustfmt,clippy --target wasm32-unknown-unknown
           rustup default ${{ matrix.toolchain }}
-          rustup target add wasm32-unknown-unknown
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         toolchain:
           - stable
-          # we need 1.58 as it has format strings
-          - 1.58
+          # minimum version for Yew
+          - 1.60
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         toolchain:
           - stable
           # minimum version for Yew
-          - 1.60
+          - "1.60"
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Rust ${{ matrix.toolchain }}
         run: |
-          rustup toolchain install ${{ matrix.toolchain }} --components rustfmt,clippy --target wasm32-unknown-unknown
+          rustup toolchain install ${{ matrix.toolchain }} --component rustfmt,clippy --target wasm32-unknown-unknown
           rustup default ${{ matrix.toolchain }}
 
       - uses: actions/cache@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,6 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   check:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         toolchain:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
 ] }
 
 openidconnect = { version = "2", optional = true }
-yew-nested-router = { version = "0.0.3", optional = true }
+yew-nested-router = { version = "0.1.0", optional = true }
 
 [features]
 router = ["yew-nested-router"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/ctron/yew-oauth2"
 categories = ["wasm", "web-programming", "gui"]
 keywords = ["yew", "oauth2", "web", "html"]
 readme = "README.md"
+rust-version = "1.60"
 
 [dependencies]
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
 ] }
 
 openidconnect = { version = "2", optional = true }
-yew-nested-router = { version = "0.0.2", optional = true }
+yew-nested-router = { version = "0.0.3", optional = true }
 
 [features]
 router = ["yew-nested-router"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-oauth2"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jens Reimann <jreimann@redhat.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -21,20 +21,20 @@ num-traits = "0.2"
 oauth2 = "4"
 reqwest = "0.11"
 serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["sync"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-yew = "0.19"
-yew-agent = "0.1"
+yew = "0.20"
 
 web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
-openidconnect = { version = "2.2", optional = true }
-yew-router-nested = { version = "0.16.1", optional = true }
+openidconnect = { version = "2", optional = true }
+yew-nested-router = { version = "0.0.2", optional = true }
 
 [features]
-router = ["yew-router-nested"]
+router = ["yew-nested-router"]
 openid = ["openidconnect"]
 
 [package.metadata.docs.rs]

--- a/src/agent/client/mod.rs
+++ b/src/agent/client/mod.rs
@@ -6,9 +6,8 @@ pub use self::oauth2::*;
 #[cfg(feature = "openid")]
 pub use openid::*;
 
-use crate::agent::LogoutOptions;
 use crate::{
-    agent::{InnerConfig, OAuth2Error},
+    agent::{InnerConfig, LogoutOptions, OAuth2Error},
     context::OAuth2Context,
 };
 use async_trait::async_trait;

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -1,0 +1,19 @@
+use crate::agent::Client;
+use std::time::Duration;
+
+#[derive(Clone, Debug)]
+pub struct AgentConfiguration<C: Client> {
+    pub config: C::Configuration,
+    pub scopes: Vec<String>,
+    pub grace_period: Duration,
+}
+
+impl<C: Client> PartialEq for AgentConfiguration<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.config == other.config
+            && self.scopes == other.scopes
+            && self.grace_period == other.grace_period
+    }
+}
+
+impl<C: Client> Eq for AgentConfiguration<C> {}

--- a/src/agent/error.rs
+++ b/src/agent/error.rs
@@ -1,0 +1,33 @@
+use crate::context::OAuth2Context;
+use core::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub enum OAuth2Error {
+    NotInitialized,
+    Configuration(String),
+    StartLogin(String),
+    LoginResult(String),
+    Storage(String),
+    Internal(String),
+}
+
+impl Display for OAuth2Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotInitialized => f.write_str("not initialized"),
+            Self::Configuration(err) => write!(f, "configuration error: {err}"),
+            Self::StartLogin(err) => write!(f, "start login error: {err}"),
+            Self::LoginResult(err) => write!(f, "login result: {err}"),
+            Self::Storage(err) => write!(f, "storage error: {err}"),
+            Self::Internal(err) => write!(f, "internal error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for OAuth2Error {}
+
+impl From<OAuth2Error> for OAuth2Context {
+    fn from(err: OAuth2Error) -> Self {
+        OAuth2Context::Failed(err.to_string())
+    }
+}

--- a/src/agent/ops.rs
+++ b/src/agent/ops.rs
@@ -1,0 +1,42 @@
+use super::{AgentConfiguration, Client, LoginOptions, LogoutOptions};
+use std::fmt::{Display, Formatter};
+
+#[derive(Clone, Debug)]
+pub enum Error {
+    /// The agent cannot be reached.
+    NoAgent,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoAgent => write!(f, "no agent"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Operations for the OAuth2 agent
+pub trait OAuth2Operations<C: Client> {
+    /// Configure the agent with a configuration.
+    ///
+    /// This is normally done by the [`crate::components::context::OAuth2`] context component.
+    fn configure(&self, config: AgentConfiguration<C>) -> Result<(), Error>;
+
+    /// Start a login flow with default options.
+    fn start_login(&self) -> Result<(), Error> {
+        self.start_login_opts(Default::default())
+    }
+
+    /// Start a login flow.
+    fn start_login_opts(&self, options: LoginOptions) -> Result<(), Error>;
+
+    /// Trigger the logout with default options.
+    fn logout(&self) -> Result<(), Error> {
+        self.logout_opts(Default::default())
+    }
+
+    /// Trigger the logout.
+    fn logout_opts(&self, options: LogoutOptions) -> Result<(), Error>;
+}

--- a/src/agent/state.rs
+++ b/src/agent/state.rs
@@ -1,0 +1,10 @@
+pub const STORAGE_KEY_CSRF_TOKEN: &str = "ctron/oauth2/csrfToken";
+pub const STORAGE_KEY_LOGIN_STATE: &str = "ctron/oauth2/loginState";
+pub const STORAGE_KEY_REDIRECT_URL: &str = "ctron/oauth2/redirectUrl";
+
+#[derive(Debug)]
+pub struct State {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    pub error: Option<String>,
+}

--- a/src/agent/support.rs
+++ b/src/agent/support.rs
@@ -73,6 +73,7 @@ pub trait OAuth2Operations<C: Client> {
     ///
     /// This is normally done by the [`crate::components::context::OAuth2`] context component.
     fn init(&mut self, config: AgentConfiguration<C>);
+
     /// Reconfigure the agent with a configuration.
     ///
     /// This is normally done by the [`crate::components::context::OAuth2`] context component.
@@ -85,15 +86,11 @@ pub trait OAuth2Operations<C: Client> {
     /// Start a login flow.
     fn start_login_opts(&mut self, options: LoginOptions);
 
-    /// Request the current state from the agent.
-    ///
-    /// The response will be sent over the link created by the bridge.
-    fn request_state(&mut self);
-
     /// Trigger the logout with default options.
     fn logout(&mut self) {
         self.logout_opts(Default::default());
     }
+
     /// Trigger the logout.
     fn logout_opts(&mut self, options: LogoutOptions);
 }

--- a/src/components/context/agent.rs
+++ b/src/components/context/agent.rs
@@ -1,0 +1,49 @@
+use crate::agent::{self, Client};
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use yew::hook;
+
+/// A wrapper for the [`agent::Agent`].
+///
+/// Required as Yew has some requirements for the type of a context, like [`PartialEq`].
+#[derive(Clone, Debug)]
+pub struct Agent<C: Client>(agent::Agent<C>, usize);
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+impl<C: Client> Agent<C> {
+    pub fn new(agent: agent::Agent<C>) -> Self {
+        let id = COUNTER.fetch_add(1, Ordering::AcqRel);
+
+        Self(agent, id)
+    }
+}
+
+impl<C: Client> PartialEq for Agent<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.1.eq(&other.1)
+    }
+}
+
+impl<C: Client> Deref for Agent<C> {
+    type Target = agent::Agent<C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<C: Client> DerefMut for Agent<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Get the authentication agent.
+#[hook]
+pub fn use_auth_agent<C>() -> Option<Agent<C>>
+where
+    C: Client,
+{
+    yew::prelude::use_context()
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -14,14 +14,8 @@ pub use failure::*;
 pub use noauth::*;
 pub use use_authentication::*;
 
-use crate::agent::{Client, OAuth2Dispatcher, OAuth2Operations};
 use yew::prelude::*;
 
 fn missing_context() -> Html {
     html!(<div> { "Unable to find OAuth2 context! This element needs to be wrapped into an `OAuth2` component somewhere in the hierarchy"} </div>)
-}
-
-fn start_login<C: Client>() {
-    log::debug!("Triggering login");
-    OAuth2Dispatcher::<C>::new().start_login();
 }

--- a/src/components/redirect/location.rs
+++ b/src/components/redirect/location.rs
@@ -10,7 +10,11 @@ pub struct LocationRedirector {}
 impl Redirector for LocationRedirector {
     type Properties = LocationProps;
 
-    fn logout(props: &Self::Properties) {
+    fn new<COMP: Component>(_: &Context<COMP>) -> Self {
+        Self {}
+    }
+
+    fn logout(&self, props: &Self::Properties) {
         log::debug!("Navigate due to logout: {}", props.logout_href);
         window().location().set_href(&props.logout_href).ok();
     }

--- a/src/components/redirect/router.rs
+++ b/src/components/redirect/router.rs
@@ -38,7 +38,7 @@ where
         log::debug!("ChangeRoute due to logout: {:?}", route);
 
         if let Some(router) = &self.router {
-            router.go(route);
+            router.push(route);
         }
     }
 }

--- a/src/components/use_authentication.rs
+++ b/src/components/use_authentication.rs
@@ -1,7 +1,7 @@
 //! The [`UseAuthentication`] component
 
 use super::missing_context;
-use crate::context::{Authentication, OAuth2Context};
+use crate::context::{use_auth_state, Authentication, OAuth2Context};
 use std::rc::Rc;
 use yew::prelude::*;
 
@@ -15,7 +15,7 @@ pub trait UseAuthenticationProperties: Clone {
 #[derive(Clone, Debug, Properties)]
 pub struct Props<C>
 where
-    C: Component,
+    C: BaseComponent,
     C::Properties: UseAuthenticationProperties,
 {
     pub children: ChildrenWithProps<C>,
@@ -23,7 +23,7 @@ where
 
 impl<C> PartialEq for Props<C>
 where
-    C: Component,
+    C: BaseComponent,
     C::Properties: UseAuthenticationProperties,
 {
     fn eq(&self, other: &Self) -> bool {
@@ -66,10 +66,10 @@ where
 #[function_component(UseAuthentication)]
 pub fn use_authentication<C>(props: &Props<C>) -> Html
 where
-    C: Component,
+    C: BaseComponent,
     C::Properties: UseAuthenticationProperties,
 {
-    let auth = use_context::<OAuth2Context>();
+    let auth = use_auth_state();
 
     html!(
         if let Some(auth) = auth {

--- a/src/context.rs
+++ b/src/context.rs
@@ -65,6 +65,12 @@ impl OAuth2Context {
     }
 }
 
+/// Get the authentication state.
+#[hook]
+pub fn use_auth_state() -> Option<OAuth2Context> {
+    use_context()
+}
+
 /// The reason why the context is un-authenticated.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Reason {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,42 +19,46 @@
 //! use yew_oauth2::prelude::*;
 //! use yew_oauth2::oauth2::*; // use `openid::*` when using OpenID connect
 //!
-//! pub struct MyApplication;
+//! #[function_component(MyApplication)]
+//! fn my_app() -> Html {
+//!   let config = Config {
+//!     client_id: "my-client".into(),
+//!     auth_url: "https://my-sso/auth/realms/my-realm/protocol/openid-connect/auth".into(),
+//!     token_url: "https://my-sso/auth/realms/my-realm/protocol/openid-connect/token".into(),
+//!   };
 //!
-//! impl Component for MyApplication {
-//!   type Message = ();
-//!   type Properties = ();
+//!   html!(
+//!     <OAuth2 config={config}>
+//!       <MyApplicationMain/>
+//!     </OAuth2>
+//!   )
+//! }
 //!
-//!   fn create(ctx: &Context<Self>) -> Self {
-//!     Self
-//!   }
+//! #[function_component(MyApplicationMain)]
+//! fn my_app_main() -> Html {
+//!   let agent = use_auth_agent().expect("Must be nested inside an OAuth2 component");
 //!
-//!   fn view(&self, ctx: &Context<Self>) -> Html {
-//!     let login = ctx.link().callback_once(|_: MouseEvent| {
-//!       OAuth2Dispatcher::<Client>::new().start_login();
-//!     });
-//!     let logout = ctx.link().callback_once(|_: MouseEvent| {
-//!       OAuth2Dispatcher::<Client>::new().logout();
-//!     });
+//!   let login = {
+//!     let agent = agent.clone();
+//!     Callback::from(move |_| {
+//!       let _ = agent.start_login();
+//!     })
+//!   };
+//!   let logout = Callback::from(move |_| {
+//!     let _ = agent.logout();
+//!   });
 //!
-//!     let config = Config {
-//!       client_id: "my-client".into(),
-//!       auth_url: "https://my-sso/auth/realms/my-realm/protocol/openid-connect/auth".into(),
-//!       token_url: "https://my-sso/auth/realms/my-realm/protocol/openid-connect/token".into(),
-//!     };
-//!
-//!     html!(
-//!       <OAuth2 config={config}>
-//!         <Failure><FailureMessage/></Failure>
-//!         <Authenticated>
-//!           <button onclick={logout}>{ "Logout" }</button>
-//!         </Authenticated>
-//!         <NotAuthenticated>
-//!           <button onclick={login.clone()}>{ "Login" }</button>
-//!         </NotAuthenticated>
-//!       </OAuth2>
-//!     )
-//!   }
+//!   html!(
+//!     <>
+//!       <Failure><FailureMessage/></Failure>
+//!       <Authenticated>
+//!         <button onclick={logout}>{ "Logout" }</button>
+//!       </Authenticated>
+//!       <NotAuthenticated>
+//!         <button onclick={login}>{ "Login" }</button>
+//!       </NotAuthenticated>
+//!     </>
+//!   )
 //! }
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,9 +70,14 @@ pub mod openid {
     pub use crate::agent::client::OpenIdClient as Client;
     pub use crate::components::context::openid::*;
     pub use crate::components::redirect::location::openid::*;
-    #[cfg(feature = "yew-router-nested")]
+    #[cfg(feature = "yew-nested-router")]
     pub use crate::components::redirect::router::openid::*;
     pub use crate::config::openid::*;
+
+    #[yew::hook]
+    pub fn use_auth_agent() -> Option<crate::components::context::Agent<Client>> {
+        crate::components::context::use_auth_agent::<Client>()
+    }
 }
 
 pub mod oauth2 {
@@ -80,7 +85,12 @@ pub mod oauth2 {
     pub use crate::agent::client::OAuth2Client as Client;
     pub use crate::components::context::oauth2::*;
     pub use crate::components::redirect::location::oauth2::*;
-    #[cfg(feature = "yew-router-nested")]
+    #[cfg(feature = "yew-nested-router")]
     pub use crate::components::redirect::router::oauth2::*;
     pub use crate::config::oauth2::*;
+
+    #[yew::hook]
+    pub fn use_auth_agent() -> Option<crate::components::context::Agent<Client>> {
+        crate::components::context::use_auth_agent::<Client>()
+    }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,8 +1,6 @@
 //! The prelude, includes most things you will need.
 
-pub use crate::agent::{
-    AgentConfiguration, LoginOptions, OAuth2Bridge, OAuth2Dispatcher, OAuth2Error, OAuth2Operations,
-};
+pub use crate::agent::{AgentConfiguration, LoginOptions, OAuth2Error, OAuth2Operations};
 pub use crate::components::*;
 pub use crate::config::*;
 pub use crate::context::*;
@@ -10,3 +8,5 @@ pub use crate::context::*;
 pub use crate::oauth2;
 #[cfg(feature = "openid")]
 pub use crate::openid;
+
+pub use crate::context::use_auth_state;

--- a/yew-oauth2-example/Cargo.toml
+++ b/yew-oauth2-example/Cargo.toml
@@ -10,11 +10,11 @@ chrono = { version = "0.4", features = ["wasmbind"] }
 gloo-timers = "0.2"
 humantime = "2"
 log = { version = "0.4", features = [] }
+serde_json = "1"
 wasm-bindgen = "0.2.79"
 wasm-logger = "0.2"
-yew = "0.19"
-yew-router = { version = "0.16", package = "yew-router-nested" }
-serde_json = "1"
+yew = { version = "0.20", features = ["csr"] }
+yew-nested-router = "0.0.2"
 
 openidconnect = { version = "2.2", optional = true, default-features = false, features = ["reqwest", "rustls-tls", "rustcrypto"] }
 

--- a/yew-oauth2-example/assets/style.scss
+++ b/yew-oauth2-example/assets/style.scss
@@ -1,0 +1,4 @@
+a {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/yew-oauth2-example/src/main.rs
+++ b/yew-oauth2-example/src/main.rs
@@ -13,6 +13,6 @@ const LOG_LEVEL: log::Level = log::Level::Trace;
 pub fn main() -> Result<(), JsValue> {
     wasm_logger::init(wasm_logger::Config::new(LOG_LEVEL));
     log::info!("Starting application");
-    yew::start_app::<app::Application>();
+    yew::Renderer::<app::Application>::new().render();
     Ok(())
 }

--- a/yew-oauth2-redirect-example/Cargo.toml
+++ b/yew-oauth2-redirect-example/Cargo.toml
@@ -4,17 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-yew-oauth2 = { path = "..", features = ["yew-router-nested"] }
-
+yew-oauth2 = { path = "..", features = ["yew-nested-router"] }
 chrono = { version = "0.4", features = ["wasmbind"] }
 gloo-timers = "0.2"
 humantime = "2"
 log = { version = "0.4", features = [] }
+serde_json = "1"
 wasm-bindgen = "0.2.79"
 wasm-logger = "0.2"
-yew = "0.19"
-yew-router = { version = "0.16", package = "yew-router-nested" }
-serde_json = "1"
+yew = { version = "0.20", features = ["csr"] }
+yew-nested-router = "0.0.2"
 
 openidconnect = { version = "2.2", optional = true, default-features = false, features = ["reqwest", "rustls-tls", "rustcrypto"] }
 

--- a/yew-oauth2-redirect-example/assets/style.scss
+++ b/yew-oauth2-redirect-example/assets/style.scss
@@ -1,0 +1,4 @@
+a {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/yew-oauth2-redirect-example/src/app.rs
+++ b/yew-oauth2-redirect-example/src/app.rs
@@ -1,171 +1,161 @@
 use crate::components::*;
 use yew::prelude::*;
+use yew_nested_router::{components::*, prelude::*};
 use yew_oauth2::prelude::*;
-use yew_router::prelude::*;
 
 #[cfg(not(feature = "openid"))]
 use yew_oauth2::oauth2::*;
 #[cfg(feature = "openid")]
 use yew_oauth2::openid::*;
 
-#[cfg(not(feature = "openid"))]
-use yew_oauth2::oauth2::Client;
-#[cfg(feature = "openid")]
-use yew_oauth2::openid::Client;
-
-#[derive(Switch, Debug, Clone, PartialEq, Eq)]
+#[derive(Target, Debug, Clone, PartialEq, Eq)]
 pub enum AppRoute {
-    #[to = "/authenticated{*}"]
     Authenticated(AuthenticatedRoute),
-    #[to = "/"]
+    #[target(index)]
     Index,
 }
 
-#[derive(Switch, Debug, Clone, PartialEq, Eq)]
+#[derive(Target, Debug, Clone, PartialEq, Eq)]
 pub enum AuthenticatedRoute {
-    #[to = "/component"]
     Component,
-    #[to = "/function"]
     Function,
-    #[to = "/use"]
     UseAuthentication,
-    #[to = "/"]
+    #[target(index)]
     Index,
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, Properties)]
-pub struct Props {}
+#[function_component(Content)]
+pub fn content() -> Html {
+    let agent = use_auth_agent().expect("Requires OAuth2Context component in parent hierarchy");
 
-pub struct Application {}
+    let login = {
+        let agent = agent.clone();
+        Callback::from(move |_: MouseEvent| {
+            if let Err(err) = agent.start_login() {
+                log::warn!("Failed to start login: {err}");
+            }
+        })
+    };
+    let logout = Callback::from(move |_: MouseEvent| {
+        if let Err(err) = agent.logout() {
+            log::warn!("Failed to logout: {err}");
+        }
+    });
 
-impl Component for Application {
-    type Message = ();
-    type Properties = Props;
-
-    fn create(_ctx: &Context<Self>) -> Self {
-        Self {}
-    }
-
-    fn view(&self, ctx: &Context<Self>) -> Html {
-        let login = ctx.link().callback_once(|_: MouseEvent| {
-            OAuth2Dispatcher::<Client>::new().start_login();
-        });
-        let logout = ctx.link().callback_once(|_: MouseEvent| {
-            OAuth2Dispatcher::<Client>::new().logout();
-        });
-
-        #[cfg(not(feature = "openid"))]
-        let config = Config {
-            client_id: "example".into(),
-            auth_url: "http://localhost:8081/realms/master/protocol/openid-connect/auth".into(),
-            token_url: "http://localhost:8081/realms/master/protocol/openid-connect/token".into(),
-        };
-
-        #[cfg(feature = "openid")]
-        let config = Config {
-            client_id: "example".into(),
-            issuer_url: "http://localhost:8081/realms/master".into(),
-            additional: Additional {
-                /*
-                Set the after logout URL to a public URL. Otherwise, the SSO server will redirect
-                back to the current page, which is detected as a new session, and will try to login
-                again, if the page requires this.
-                */
-                after_logout_url: Some("/".into()),
-                ..Default::default()
-            },
-        };
-
-        let mode = if cfg!(feature = "openid") {
-            "OpenID Connect"
-        } else {
-            "pure OAuth2"
-        };
-
-        html!(
-            <>
-            <h1> { "Redirect example (" } {mode} { ")"} </h1>
-
-            <OAuth2
-                {config}
-                scopes={vec!["openid".to_string()]}
-                >
-
-                <Failure>
-                    <ul>
-                        <li><FailureMessage/></li>
-                    </ul>
-                </Failure>
-
-                { /* We show the full menu structure here */ html!() }
+    html!(
+        <Router<AppRoute>>
+            <Failure>
                 <ul>
-                    <li><RouterAnchor<AppRoute> route={AppRoute::Index}> { "Public" } </RouterAnchor<AppRoute>></li>
-                    <li><RouterAnchor<AppRoute> route={AppRoute::Authenticated(AuthenticatedRoute::Index)}> { "Authenticated" } </RouterAnchor<AppRoute>>
-                        <ul>
-                            <li><RouterAnchor<AppRoute> route={AppRoute::Authenticated(AuthenticatedRoute::Component)}> { "Component" } </RouterAnchor<AppRoute>></li>
-                            <li><RouterAnchor<AppRoute> route={AppRoute::Authenticated(AuthenticatedRoute::Function)}> { "Function" } </RouterAnchor<AppRoute>></li>
-                            <li><RouterAnchor<AppRoute> route={AppRoute::Authenticated(AuthenticatedRoute::UseAuthentication)}> { "Use" } </RouterAnchor<AppRoute>></li>
-                        </ul>
-                    </li>
+                    <li><FailureMessage/></li>
                 </ul>
+            </Failure>
 
-                <aside>
-                    <h2>{"Internal state"}</h2>
-                    <div style="max-height: 300px; overflow: auto;">
+            /* We show the full menu structure here */
+            <ul>
+                <li><Link<AppRoute> target={AppRoute::Index}> { "Public" } </Link<AppRoute>></li>
+                <li><Link<AppRoute> target={AppRoute::Authenticated(AuthenticatedRoute::Index)}> { "Authenticated" } </Link<AppRoute>>
+                    <ul>
+                        <li><Link<AppRoute> target={AppRoute::Authenticated(AuthenticatedRoute::Component)}> { "Component" } </Link<AppRoute>></li>
+                        <li><Link<AppRoute> target={AppRoute::Authenticated(AuthenticatedRoute::Function)}> { "Function" } </Link<AppRoute>></li>
+                        <li><Link<AppRoute> target={AppRoute::Authenticated(AuthenticatedRoute::UseAuthentication)}> { "Use" } </Link<AppRoute>></li>
+                    </ul>
+                </li>
+            </ul>
+
+            <aside>
+                <h2>{"Internal state"}</h2>
+                <div style="max-height: 300px; overflow: auto;">
                     <Debug/>
-                    </div>
-                </aside>
+                </div>
+            </aside>
 
-                <aside>
-                    /* Always show the appropriate button */
-                    <Authenticated>
-                        <p>
-                            <button onclick={logout}>{ "Logout" }</button>
-                        </p>
-                        <Expiration/>
-                    </Authenticated>
-                    <NotAuthenticated>
-                        <p>
-                            <button onclick={login.clone()}>{ "Login" }</button>
-                        </p>
-                    </NotAuthenticated>
-                </aside>
+            <aside>
+                /* Always show the appropriate button */
+                <Authenticated>
+                    <p>
+                        <button onclick={logout}>{ "Logout" }</button>
+                    </p>
+                    <Expiration/>
+                </Authenticated>
+                <NotAuthenticated>
+                    <p>
+                        <button onclick={login.clone()}>{ "Login" }</button>
+                    </p>
+                </NotAuthenticated>
+            </aside>
 
-                <Router<AppRoute>
-                    render = { Router::render(|switch: AppRoute| {
-                        match switch {
-                            AppRoute::Index => html!(<p> { "Welcome"} </p>),
-                            /*
-                            When the user requests an authenticated page, we hide this behind
-                            the `RouterRedirect` component. It will trigger a login when
-                            required, but not show any children when not logged in, but forward
-                            to the logout route instead.
+            <Switch<AppRoute> render={|switch| match switch {
+                AppRoute::Index => html!(<p> { "Welcome"} </p>),
+                /*
+                When the user requests an authenticated page, we hide this behind
+                the `RouterRedirect` component. It will trigger a login when
+                required, but not show any children when not logged in, but forward
+                to the logout route instead.
 
-                            **NOTE:** For OpenID Connect it is important to also set the
-                            `after_logout_url` in the client configuration to some public route.
-                            */
-                            AppRoute::Authenticated(authenticated) => html!(
-                                <RouterRedirect<AppRoute> logout={ AppRoute::Index }>
-                                {
-                                    match authenticated {
-                                            AuthenticatedRoute::Index => html!(<p> { "You are logged in"} </p>),
-                                            AuthenticatedRoute::Component => html!(<ViewAuthInfoComponent />),
-                                            AuthenticatedRoute::Function => html!(<ViewAuthInfoFunctional />),
-                                            AuthenticatedRoute::UseAuthentication => html!(
-                                                <UseAuthentication<ViewUseAuth>>
-                                                    <ViewUseAuth/>
-                                                </UseAuthentication<ViewUseAuth>>
-                                            ),
-                                        }
-                                }
-                                </RouterRedirect<AppRoute>>
-                            )
-                        }
-                    })}
-                />
+                **NOTE:** For OpenID Connect it is important to also set the
+                `after_logout_url` in the client configuration to some public route.
+                */
+                AppRoute::Authenticated(authenticated) => html!(
+                    <RouterRedirect<AppRoute> logout={ AppRoute::Index }>
+                    {
+                        match authenticated {
+                                AuthenticatedRoute::Index => html!(<p> { "You are logged in"} </p>),
+                                AuthenticatedRoute::Component => html!(<ViewAuthInfoComponent />),
+                                AuthenticatedRoute::Function => html!(<ViewAuthInfoFunctional />),
+                                AuthenticatedRoute::UseAuthentication => html!(
+                                    <UseAuthentication<ViewUseAuth>>
+                                        <ViewUseAuth/>
+                                    </UseAuthentication<ViewUseAuth>>
+                                ),
+                            }
+                    }
+                    </RouterRedirect<AppRoute>>
+                )
+            }}/>
+        </Router<AppRoute>>
+    )
+}
 
-            </OAuth2>
-            </>
-        )
-    }
+#[function_component(Application)]
+pub fn app() -> Html {
+    #[cfg(not(feature = "openid"))]
+    let config = Config {
+        client_id: "example".into(),
+        auth_url: "http://localhost:8081/realms/master/protocol/openid-connect/auth".into(),
+        token_url: "http://localhost:8081/realms/master/protocol/openid-connect/token".into(),
+    };
+
+    #[cfg(feature = "openid")]
+    let config = Config {
+        client_id: "example".into(),
+        issuer_url: "http://localhost:8081/realms/master".into(),
+        additional: Additional {
+            /*
+            Set the after logout URL to a public URL. Otherwise, the SSO server will redirect
+            back to the current page, which is detected as a new session, and will try to login
+            again, if the page requires this.
+            */
+            after_logout_url: Some("/".into()),
+            ..Default::default()
+        },
+    };
+
+    let mode = if cfg!(feature = "openid") {
+        "OpenID Connect"
+    } else {
+        "pure OAuth2"
+    };
+
+    html!(
+        <>
+        <h1> { "Redirect example (" } {mode} { ")"} </h1>
+
+        <OAuth2
+            {config}
+            scopes={vec!["openid".to_string()]}
+            >
+            <Content />
+        </OAuth2>
+        </>
+    )
 }

--- a/yew-oauth2-redirect-example/src/main.rs
+++ b/yew-oauth2-redirect-example/src/main.rs
@@ -13,6 +13,6 @@ const LOG_LEVEL: log::Level = log::Level::Trace;
 pub fn main() -> Result<(), JsValue> {
     wasm_logger::init(wasm_logger::Config::new(LOG_LEVEL));
     log::info!("Starting application");
-    yew::start_app::<app::Application>();
+    yew::Renderer::<app::Application>::new().render();
     Ok(())
 }


### PR DESCRIPTION
This rewrites some of the internals, as Yew dropped the support for Agents.

closes #5