### PR TITLE
Add `audience` config option

### DIFF
--- a/src/agent/client/oauth2.rs
+++ b/src/agent/client/oauth2.rs
@@ -79,7 +79,7 @@ impl Client for OAuth2Client {
 
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
-        let (url, state) = client
+        let mut req = client
             .authorize_url(CsrfToken::new_random)
             .add_scopes(
                 config
@@ -88,8 +88,13 @@ impl Client for OAuth2Client {
                     .map(|s| Scope::new(s.to_string()))
                     .collect::<Vec<_>>(),
             )
-            .set_pkce_challenge(pkce_challenge)
-            .url();
+            .set_pkce_challenge(pkce_challenge);
+
+        if let Some(audience) = &config.audience {
+            req = req.add_extra_param("audience".to_string(), audience.clone())
+        }
+
+        let (url, state) = req.url();
 
         Ok(LoginContext {
             url,

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -139,6 +139,10 @@ impl Client for OpenIdClient {
             req = req.add_scope(Scope::new(scope.clone()));
         }
 
+        if let Some(audience) = &config.audience {
+            req = req.add_extra_param("audience".to_string(), audience);
+        }
+
         let (url, state, nonce) = req.set_pkce_challenge(pkce_challenge).url();
 
         Ok(LoginContext {

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -6,6 +6,7 @@ pub struct AgentConfiguration<C: Client> {
     pub config: C::Configuration,
     pub scopes: Vec<String>,
     pub grace_period: Duration,
+    pub audience: Option<String>,
 }
 
 impl<C: Client> PartialEq for AgentConfiguration<C> {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -90,6 +90,7 @@ where
 pub struct InnerConfig {
     scopes: Vec<String>,
     grace_period: Duration,
+    audience: Option<String>,
 }
 
 impl<C> InnerAgent<C>
@@ -228,6 +229,7 @@ where
         let inner = InnerConfig {
             scopes: config.scopes,
             grace_period: config.grace_period,
+            audience: config.audience,
         };
 
         Ok((client, inner))

--- a/src/components/context/mod.rs
+++ b/src/components/context/mod.rs
@@ -28,6 +28,9 @@ pub struct Props<C: Client> {
     #[prop_or(Duration::from_secs(30))]
     pub grace_period: Duration,
 
+    // the audience to be associated to the access tokens inside this context
+    pub audience: Option<String>,
+
     /// Children which will have access to the [`OAuth2Context`].
     #[prop_or_default]
     pub children: Children,
@@ -116,6 +119,7 @@ impl<C: Client> OAuth2<C> {
             config: props.config.clone(),
             scopes: props.scopes.clone(),
             grace_period: props.grace_period,
+            audience: props.audience.clone(),
         }
     }
 }


### PR DESCRIPTION
This PR adds a new `audience` config option. Audience is part of the OAuth2 protocol and I needed this change to access my API using the JWT token this library provides. I'm using Auth0 and youy can find [more information about the audience here](https://community.auth0.com/t/what-is-the-audience/71414).

The value for the audience is provided like so:

```jsx
  <OAuth2
      {config}
      audience="https://myapp.eu.auth0.com/api/v1/"
      >
      <Content />
  </OAuth2>
```

Thanks for the great work on this useful library!