### PR TITLE
upgrade yew to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-yew = "0.20"
+yew = "0.21.0"
 
 web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
 openidconnect = { version = "3.0", optional = true }
-yew-nested-router = { version = ">=0.2, <0.4", optional = true }
+yew-nested-router = { git = "https://github.com/mh84/yew-nested-router", rev = "de83197b27eef473afcf8a77776cd3bd245e2d56", optional = true }
 
 [features]
 # Enable for Yew nested router support

--- a/src/components/redirect/location.rs
+++ b/src/components/redirect/location.rs
@@ -23,14 +23,14 @@ impl Redirector for LocationRedirector {
 #[derive(Clone, Debug, PartialEq, Properties)]
 pub struct LocationProps {
     #[prop_or_default]
-    pub children: Option<Children>,
+    pub children: Children,
 
     pub logout_href: String,
 }
 
 impl RedirectorProperties for LocationProps {
-    fn children(&self) -> Option<&Children> {
-        self.children.as_ref()
+    fn children(&self) -> &Children {
+        &self.children
     }
 }
 

--- a/src/components/redirect/mod.rs
+++ b/src/components/redirect/mod.rs
@@ -19,7 +19,7 @@ pub trait Redirector: 'static {
 }
 
 pub trait RedirectorProperties: yew::Properties {
-    fn children(&self) -> Option<&Children>;
+    fn children(&self) -> &Children;
 }
 
 #[derive(Debug, Clone)]
@@ -104,10 +104,7 @@ where
     fn view(&self, ctx: &Context<Self>) -> Html {
         match self.auth {
             None => missing_context(),
-            Some(OAuth2Context::Authenticated(..)) => match ctx.props().children() {
-                Some(children) => html!({for children.iter()}),
-                None => html!(),
-            },
+            Some(OAuth2Context::Authenticated(..)) => html!({for ctx.props().children().iter()}),
             _ => html!(),
         }
     }

--- a/src/components/redirect/router.rs
+++ b/src/components/redirect/router.rs
@@ -49,7 +49,7 @@ where
     R: Target + 'static,
 {
     #[prop_or_default]
-    pub children: Option<Children>,
+    pub children: Children,
     pub logout: R,
 }
 
@@ -57,8 +57,8 @@ impl<R> RedirectorProperties for RouterProps<R>
 where
     R: Target + 'static,
 {
-    fn children(&self) -> Option<&Children> {
-        self.children.as_ref()
+    fn children(&self) -> &Children {
+        &self.children
     }
 }
 

--- a/yew-oauth2-example/Cargo.toml
+++ b/yew-oauth2-example/Cargo.toml
@@ -13,8 +13,8 @@ log = { version = "0.4", features = [] }
 serde_json = "1"
 wasm-bindgen = "0.2.79"
 wasm-logger = "0.2"
-yew = { version = "0.20", features = ["csr"] }
-yew-nested-router = "0.2.0"
+yew = { version = "0.21", features = ["csr"] }
+yew-nested-router = { git = "https://github.com/mh84/yew-nested-router", rev = "de83197b27eef473afcf8a77776cd3bd245e2d56" }
 
 openidconnect = { version = "3.0", optional = true }
 

--- a/yew-oauth2-redirect-example/Cargo.toml
+++ b/yew-oauth2-redirect-example/Cargo.toml
@@ -12,8 +12,8 @@ log = { version = "0.4", features = [] }
 serde_json = "1"
 wasm-bindgen = "0.2.79"
 wasm-logger = "0.2"
-yew = { version = "0.20", features = ["csr"] }
-yew-nested-router = "0.2.0"
+yew = { version = "0.21.0", features = ["csr"] }
+yew-nested-router = { git = "https://github.com/mh84/yew-nested-router", rev = "de83197b27eef473afcf8a77776cd3bd245e2d56" }
 
 openidconnect = { version = "3.0", optional = true }
 


### PR DESCRIPTION
While trying out the redirect example and updating yew to newly released 0.21 i needed to make some adjustments i want to share.

Please reach out for me if anything is not working as intended.

The related changes to yew-nested-router are https://github.com/ctron/yew-nested-router/pull/7

The dependencies here need to be fixed once yew-nested-router is accepted.