### PR TITLE
Add support for multiple audiences

### DIFF
--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -102,6 +102,8 @@ impl Client for OpenIdClient {
 
         let client =
             CoreClient::from_provider_metadata(metadata, ClientId::new(config.client_id), None);
+        let valid_audiences = config.additional.valid_audiences.unwrap_or(vec![config.client_id]);
+        client.id_token_verifier().set_other_audience_verifier_fn(|aud| valid_audiences.contains(aud));
 
         Ok(Self {
             client,

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -100,10 +100,18 @@ impl Client for OpenIdClient {
 
         let after_logout_url = config.additional.after_logout_url;
 
-        let client =
-            CoreClient::from_provider_metadata(metadata, ClientId::new(config.client_id), None);
-        let valid_audiences = config.additional.valid_audiences.unwrap_or(vec![config.client_id]);
-        client.id_token_verifier().set_other_audience_verifier_fn(|aud| valid_audiences.contains(aud));
+        let client = CoreClient::from_provider_metadata(
+            metadata,
+            ClientId::new(config.client_id.clone()),
+            None,
+        );
+        let valid_audiences = config
+            .additional
+            .valid_audiences
+            .unwrap_or(vec![config.client_id.clone()]);
+        client
+            .id_token_verifier()
+            .set_other_audience_verifier_fn(|aud| valid_audiences.contains(aud));
 
         Ok(Self {
             client,

--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -10,6 +10,7 @@ pub struct AgentConfiguration<C: Client> {
     pub grace_period: Duration,
     pub audience: Option<String>,
     pub options: Option<LoginOptions>,
+    pub valid_audiences: Option<Vec<String>>,
 }
 
 impl<C: Client> PartialEq for AgentConfiguration<C> {

--- a/src/components/context/mod.rs
+++ b/src/components/context/mod.rs
@@ -34,6 +34,9 @@ pub struct Props<C: Client> {
     #[prop_or_default]
     pub audience: Option<String>,
 
+    #[prop_or_default]
+    pub valid_audiences: Option<Vec<String>>,
+
     /// Children which will have access to the [`OAuth2Context`].
     #[prop_or_default]
     pub children: Children,
@@ -134,8 +137,9 @@ impl<C: Client> OAuth2<C> {
             config: props.config.clone(),
             scopes: props.scopes.clone(),
             grace_period: props.grace_period,
-            audience: props.audience.clone(),
+            valid_audiences: props.valid_audiences.clone(),
             options: props.options.clone(),
+            audience: props.audience.clone(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub mod openid {
         /// The defaults to `post_logout_redirect_uri` for OpenID RP initiated logout.
         /// However, e.g. older Keycloak instances require this to be `redirect_uri`.
         pub post_logout_redirect_name: Option<String>,
+        pub valid_audiences: Option<Vec<String>>
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub mod openid {
         /// The defaults to `post_logout_redirect_uri` for OpenID RP initiated logout.
         /// However, e.g. older Keycloak instances require this to be `redirect_uri`.
         pub post_logout_redirect_name: Option<String>,
-        pub valid_audiences: Option<Vec<String>>
+        pub valid_audiences: Option<Vec<String>>,
     }
 }
 


### PR DESCRIPTION
The OIDC provider Zitadel returns multiple audiences. Since I use Zitadel I added the option to have more than one audience in the configuration. If none are provided the client_id is used as only valid audience.