### PR TITLE
refactor: make some options non-exhaustive

### DIFF
--- a/src/agent/config.rs
+++ b/src/agent/config.rs
@@ -1,7 +1,6 @@
+use super::LoginOptions;
 use crate::agent::Client;
 use std::time::Duration;
-
-use super::LoginOptions;
 
 #[derive(Clone, Debug)]
 pub struct AgentConfiguration<C: Client> {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -25,14 +25,29 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::spawn_local;
 use yew::Callback;
 
+/// Options for the login process
+///
+/// ## Non-exhaustive struct
+///
+/// The struct is "non exhaustive", which means that it is possible to add fields without breaking the API.
+///
+/// In order to create an instance, follow the following pattern:
+///
+/// ```rust
+/// # use reqwest::Url;
+/// # use yew_oauth2::prelude::LoginOptions;
+/// # let url = Url::parse("https://example.com").unwrap();
+/// let opts = LoginOptions::default().with_redirect_url(url);
+/// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct LoginOptions {
-    pub query: HashMap<String, String>,
+    pub(crate) query: HashMap<String, String>,
 
     /// Defines the redirect URL.
     ///
     /// If this field is empty, the current URL is used as a redirect URL.
-    pub redirect_url: Option<Url>,
+    pub(crate) redirect_url: Option<Url>,
 }
 
 impl LoginOptions {
@@ -53,18 +68,29 @@ impl LoginOptions {
         self
     }
 
-    pub fn with_redirect_url(mut self, redirect_url: Url) -> Self {
-        self.redirect_url = Some(redirect_url);
+    pub fn with_redirect_url(mut self, redirect_url: impl Into<Url>) -> Self {
+        self.redirect_url = Some(redirect_url.into());
         self
     }
 }
 
+/// Options for the logout process
+///
+///**NOTE**: This is a non-exhaustive struct. See [`LoginOptions`] for an example on how to work with this.
+#[non_exhaustive]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct LogoutOptions {
     /// An optional target to navigate to after the user was logged out.
     ///
     /// This would override any settings from the client configuration.
-    pub target: Option<Url>,
+    pub(crate) target: Option<Url>,
+}
+
+impl LogoutOptions {
+    pub fn with_target(mut self, target: impl Into<Url>) -> Self {
+        self.target = Some(target.into());
+        self
+    }
 }
 
 pub enum Msg<C>

--- a/src/components/context/mod.rs
+++ b/src/components/context/mod.rs
@@ -4,11 +4,9 @@ mod agent;
 
 pub use agent::*;
 
-use crate::context::LatestAccessToken;
-use crate::prelude::LoginOptions;
 use crate::{
-    agent::{AgentConfiguration, Client, OAuth2Operations},
-    context::OAuth2Context,
+    agent::{AgentConfiguration, Client, LoginOptions, OAuth2Operations},
+    context::{LatestAccessToken, OAuth2Context},
 };
 use agent::Agent as AgentContext;
 use std::time::Duration;


### PR DESCRIPTION
BREAKING-CHANGE: In order to allow adding new options in the future,
 the structs LoginOptions and LogoutOptions have been made
 non-exhaustive. Adding some documentation on how to work with them.

@kate-shine @AlexandreRoba @DerKnerd It would be great if you could give this a quick look. I think this should simplify adding new fields in the future. But it will break the API right now. Which the two pending PRs seem to do anyway. That's fine, but let's take the opportunity to improve this.