### PR TITLE
fix duplicated query pairs from login options

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -590,11 +590,6 @@ where
         let mut login_url = login_context.url;
 
         login_url.query_pairs_mut().extend_pairs(options.query);
-        if let Some(options) = &config.default_login_options {
-            login_url
-                .query_pairs_mut()
-                .extend_pairs(options.query.clone());
-        }
 
         // the next call will most likely navigate away from this page
 


### PR DESCRIPTION
As options in line 592 are now already the config.default_login_options, the removed lines will lead to duplicated query pairs, this pr will fix this.