### PR TITLE
update openidconnect and oauth2 libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ gloo-utils = "0.2"
 js-sys = "0.3"
 log = "0.4"
 num-traits = "0.2"
-oauth2 = "4"
-reqwest = "0.11"
+oauth2 = "5.0.0-rc.1"
+reqwest = "0.12"
 serde = { version = "1", features = ["derive"] }
 time = { version = "0.3", features = ["wasm-bindgen"] }
 tokio = { version = "1", features = ["sync"] }
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
-openidconnect = { version = "3.0", optional = true }
+openidconnect = { version = "4.0.0-rc.1", optional = true, features = ["timing-resistant-secret-traits"] }
 yew-nested-router = { version = "0.7.0", optional = true }
 
 [features]


### PR DESCRIPTION
I needed some fixes from https://github.com/ramosbugs/openidconnect-rs/commit/1d97e0e1fcbab6dbcea60abb5f33c895c8499848, so I ported the code to oauth2 `5.0.0-rc.1` and openidconnect `4.0.0-rc.1`.

I loosely followed https://github.com/ramosbugs/openidconnect-rs/blob/main/UPGRADE.md and https://github.com/ramosbugs/oauth2-rs/blob/main/UPGRADE.md.