### PR TITLE
feat: allow issuer_match verification to be skipped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ web-sys = { version = "0.3", features = [
     "Window",
 ] }
 
-openidconnect = { version = "4.0.1", optional = true }
+openidconnect = { version = "4.0.1", optional = true , features = ["timing-resistant-secret-traits"]}
 yew-nested-router = { version = "0.7.0", optional = true }
 
 [features]

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -46,6 +46,8 @@ pub struct OpenIdClient {
     post_logout_redirect_name: Option<String>,
     /// Additional audiences of the ID token which are considered trustworthy
     additional_trusted_audiences: Vec<String>,
+    /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
+    pub require_issuer_match: bool,
 }
 
 /// Additional metadata read from the discovery endpoint
@@ -93,6 +95,7 @@ impl Client for OpenIdClient {
             after_logout_url,
             post_logout_redirect_name,
             additional_trusted_audiences,
+            require_issuer_match,
         } = config;
 
         let issuer = IssuerUrl::new(issuer_url)
@@ -120,6 +123,7 @@ impl Client for OpenIdClient {
             after_logout_url,
             post_logout_redirect_name,
             additional_trusted_audiences,
+            require_issuer_match,
         })
     }
 
@@ -194,6 +198,7 @@ impl Client for OpenIdClient {
                     &self
                         .client
                         .id_token_verifier()
+                        .require_issuer_match(self.require_issuer_match)
                         .set_other_audience_verifier_fn(|aud| {
                             self.additional_trusted_audiences.contains(aud)
                         }),

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -103,11 +103,15 @@ impl Client for OpenIdClient {
             post_logout_redirect_name,
             additional_trusted_audiences,
             require_issuer_match,
+            follow_client_redirects,
         } = config;
 
+        let redirect_policy = match follow_client_redirects {
+            true => openidconnect::reqwest::redirect::Policy::limited(1),
+            false => openidconnect::reqwest::redirect::Policy::none(),
+        };
         let http_client = openidconnect::reqwest::ClientBuilder::new()
-            // Following redirects opens the client up to SSRF vulnerabilities.
-            // .redirect(openidconnect::reqwest::redirect::Policy::none())
+            .redirect(redirect_policy)
             .build()
             .map_err(|err| {
                 OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub mod openid {
         ///
         /// Those audiences are allowed in addition to the client ID.
         pub additional_trusted_audiences: Vec<String>,
+        /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
+        pub require_issuer_match: bool,
     }
 
     impl Config {
@@ -45,6 +47,7 @@ pub mod openid {
                 after_logout_url: None,
                 post_logout_redirect_name: None,
                 additional_trusted_audiences: vec![],
+                require_issuer_match: true,
             }
         }
 
@@ -98,6 +101,12 @@ pub mod openid {
         ) -> Self {
             self.additional_trusted_audiences
                 .push(additional_trusted_audience.into());
+            self
+        }
+
+        /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
+        pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
+            self.require_issuer_match = require_issuer_match;
             self
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,8 @@ pub mod openid {
         pub additional_trusted_audiences: Vec<String>,
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub require_issuer_match: bool,
+        /// Allow following redirect (Be careful it opens the client up to SSRF vulnerabilities)
+        pub follow_client_redirects: bool,
     }
 
     impl Config {
@@ -48,6 +50,7 @@ pub mod openid {
                 post_logout_redirect_name: None,
                 additional_trusted_audiences: vec![],
                 require_issuer_match: true,
+                follow_client_redirects: false,
             }
         }
 
@@ -107,6 +110,12 @@ pub mod openid {
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
             self.require_issuer_match = require_issuer_match;
+            self
+        }
+
+        /// Allow following redirect (Be careful it opens the client up to SSRF vulnerabilities)
+        pub fn with_follow_client_redirects(mut self, follow_redirect: bool) -> Self {
+            self.follow_client_redirects = follow_redirect;
             self
         }
     }


### PR DESCRIPTION
When using tool like, ory, we create local tunnel to the issuer, which change the expected issuer