### PR TITLE
feat: allow client to be configure with urls instead of metadata

### DIFF
--- a/src/agent/client/oauth2.rs
+++ b/src/agent/client/oauth2.rs
@@ -33,6 +33,7 @@ impl OAuth2Client {
     fn make_authenticated(result: BasicTokenResponse) -> OAuth2Context {
         OAuth2Context::Authenticated(Authentication {
             access_token: result.access_token().secret().to_string(),
+            id_token: None,
             refresh_token: result.refresh_token().map(|t| t.secret().to_string()),
             expires: expires(result.expires_in()),
             #[cfg(feature = "openid")]

--- a/src/agent/client/openid.rs
+++ b/src/agent/client/openid.rs
@@ -8,11 +8,12 @@ use crate::{
 };
 use async_trait::async_trait;
 use gloo_utils::window;
-use oauth2::TokenResponse;
+use oauth2::TokenResponse as _;
 use openidconnect::{
-    AuthorizationCode, ClientId, CsrfToken, EmptyAdditionalClaims, EndpointMaybeSet,
-    EndpointNotSet, EndpointSet, IdTokenClaims, IssuerUrl, Nonce, PkceCodeChallenge,
-    PkceCodeVerifier, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EmptyAdditionalClaims, EndpointNotSet,
+    EndpointSet, IdTokenClaims, IssuerUrl, JsonWebKeySet, JsonWebKeySetUrl, Nonce,
+    PkceCodeChallenge, PkceCodeVerifier, ProviderMetadata, RedirectUrl, RefreshToken, Scope,
+    TokenResponse, TokenUrl, UserInfoUrl,
     core::{
         CoreAuthDisplay, CoreAuthenticationFlow, CoreClaimName, CoreClaimType, CoreClient,
         CoreClientAuthMethod, CoreGenderClaim, CoreGrantType, CoreJsonWebKey,
@@ -81,7 +82,7 @@ pub type ExtendedClient = CoreClient<
     EndpointNotSet,
     EndpointNotSet,
     EndpointSet,
-    EndpointMaybeSet,
+    EndpointSet,
 >;
 
 #[async_trait(? Send)]
@@ -95,63 +96,21 @@ impl Client for OpenIdClient {
     );
 
     async fn from_config(config: Self::Configuration) -> Result<Self, OAuth2Error> {
-        let openid::Config {
-            client_id,
-            issuer_url,
-            end_session_url,
-            after_logout_url,
-            post_logout_redirect_name,
-            additional_trusted_audiences,
-            require_issuer_match,
-        } = config;
-
-        let http_client = openidconnect::reqwest::ClientBuilder::new()
-            // we can't control redirect here, as we're using WASM request, which basically is the browser
-            .build()
-            .map_err(|err| {
-                OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))
-            })?;
-
-        let issuer = IssuerUrl::new(issuer_url)
-            .map_err(|err| OAuth2Error::Configuration(format!("invalid issuer URL: {err}")))?;
-
-        let metadata = ExtendedProviderMetadata::discover_async(issuer, &http_client)
-            .await
-            .map_err(|err| {
-                OAuth2Error::Configuration(format!("Failed to discover client: {err}"))
-            })?;
-
-        // Extract the URIs we MUST have
-        let auth_uri = metadata.authorization_endpoint().clone();
-
-        let token_uri = metadata
-            .token_endpoint()
-            .ok_or_else(|| {
-                OAuth2Error::Configuration("Provider missing required token endpoint".into())
-            })?
-            .clone();
-
-        let end_session_url = end_session_url
-            .map(|url| Url::parse(&url))
-            .transpose()
-            .map_err(|err| {
-                OAuth2Error::Configuration(format!("Unable to parse end_session_url: {err}"))
-            })?
-            .or_else(|| metadata.additional_metadata().end_session_endpoint.clone());
-
-        let client = CoreClient::from_provider_metadata(metadata, ClientId::new(client_id), None)
-            .set_auth_uri(auth_uri)
-            .set_token_uri(token_uri);
-
-        Ok(Self {
-            http_client,
-            client,
-            end_session_url,
-            after_logout_url,
-            post_logout_redirect_name,
-            additional_trusted_audiences,
-            require_issuer_match,
-        })
+        match (
+            &config.jwks_url,
+            &config.auth_url,
+            &config.token_url,
+            &config.user_info_url,
+        ) {
+            (Some(_), Some(_), Some(_), Some(_)) => {
+                log::debug!("Constructing client from feeded urls");
+                Self::from_urls(config).await
+            }
+            _ => {
+                log::debug!("Constructing client from provider metadata");
+                Self::from_metadata(config).await
+            }
+        }
     }
 
     fn set_redirect_uri(mut self, url: Url) -> Self {
@@ -239,6 +198,7 @@ impl Client for OpenIdClient {
         Ok((
             OAuth2Context::Authenticated(Authentication {
                 access_token: result.access_token().secret().to_string(),
+                id_token: result.id_token().map(|t| t.to_string()),
                 refresh_token: result.refresh_token().map(|t| t.secret().to_string()),
                 expires: expires(result.expires_in()),
                 claims: Some(claims.clone()),
@@ -264,6 +224,7 @@ impl Client for OpenIdClient {
         Ok((
             OAuth2Context::Authenticated(Authentication {
                 access_token: result.access_token().secret().to_string(),
+                id_token: result.id_token().map(|t| t.to_string()),
                 refresh_token: result.refresh_token().map(|t| t.secret().to_string()),
                 expires: expires(result.expires_in()),
                 claims: Some(session_state.1.clone()),
@@ -322,5 +283,167 @@ impl OpenIdClient {
         } else {
             window().location().href().ok()
         }
+    }
+    async fn from_metadata(config: openid::Config) -> Result<Self, OAuth2Error> {
+        let openid::Config {
+            client_id,
+            issuer_url,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+            ..
+        } = config;
+
+        let http_client = openidconnect::reqwest::ClientBuilder::new()
+            // we can't control redirect here, as we're using WASM request, which basically is the browser
+            .build()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))
+            })?;
+
+        let issuer = IssuerUrl::new(issuer_url)
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid issuer URL: {err}")))?;
+
+        let metadata = ExtendedProviderMetadata::discover_async(issuer, &http_client)
+            .await
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Failed to discover client: {err}"))
+            })?;
+
+        // Extract the URIs we MUST have
+        let auth_uri = metadata.authorization_endpoint().clone();
+
+        let token_uri = metadata
+            .token_endpoint()
+            .ok_or_else(|| {
+                OAuth2Error::Configuration("Provider missing required token endpoint".into())
+            })?
+            .clone();
+
+        let user_info_uri = metadata
+            .userinfo_endpoint()
+            .ok_or_else(|| {
+                OAuth2Error::Configuration("Provider missing required auth info endpoint".into())
+            })?
+            .clone();
+
+        let end_session_url = end_session_url
+            .map(|url| Url::parse(&url))
+            .transpose()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Unable to parse end_session_url: {err}"))
+            })?
+            .or_else(|| metadata.additional_metadata().end_session_endpoint.clone());
+
+        let client = CoreClient::from_provider_metadata(metadata, ClientId::new(client_id), None)
+            .set_auth_uri(auth_uri)
+            .set_token_uri(token_uri)
+            .set_user_info_url(user_info_uri);
+        Ok(Self {
+            http_client,
+            client,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+        })
+    }
+
+    async fn from_urls(config: openid::Config) -> Result<Self, OAuth2Error> {
+        let openid::Config {
+            client_id,
+            issuer_url,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+            jwks_url,
+            auth_url,
+            token_url,
+            user_info_url,
+        } = config;
+
+        let http_client = openidconnect::reqwest::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            // .redirect(openidconnect::reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Failed to build HTTP client: {err}"))
+            })?;
+
+        let issuer = IssuerUrl::new(issuer_url)
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid issuer URL: {err}")))?;
+
+        let auth_uri = auth_url
+            .map(AuthUrl::new)
+            .transpose()
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid auth URL: {err}")))?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing auth url".to_string(),
+                )
+            })?;
+
+        let token_uri = token_url
+            .map(TokenUrl::new)
+            .transpose()
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid token URL: {err}")))?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing token url".to_string(),
+                )
+            })?;
+
+        let jwks_uri = jwks_url
+            .map(JsonWebKeySetUrl::new)
+            .transpose()
+            .map_err(|err| OAuth2Error::Configuration(format!("invalid jwks URL: {err}")))?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing jwks url".to_string(),
+                )
+            })?;
+
+        let jwks = JsonWebKeySet::fetch_async(&jwks_uri, &http_client)
+            .await
+            .map_err(|err| OAuth2Error::Configuration(format!("Could not fetch jwks: {err}")))?;
+
+        let user_info_url = user_info_url
+            .map(UserInfoUrl::new)
+            .transpose()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Unable to parse user_info_url: {err}"))
+            })?
+            .ok_or_else(|| {
+                OAuth2Error::Configuration(
+                    "Cannot build Auth2 client without metadata: missing user_info url".to_string(),
+                )
+            })?;
+
+        let end_session_url = end_session_url
+            .map(|url| Url::parse(&url))
+            .transpose()
+            .map_err(|err| {
+                OAuth2Error::Configuration(format!("Unable to parse end_session_url: {err}"))
+            })?;
+
+        let client = CoreClient::new(ClientId::new(client_id), issuer, jwks)
+            .set_auth_uri(auth_uri)
+            .set_token_uri(token_uri)
+            .set_user_info_url(user_info_url);
+
+        Ok(Self {
+            http_client,
+            client,
+            end_session_url,
+            after_logout_url,
+            post_logout_redirect_name,
+            additional_trusted_audiences,
+            require_issuer_match,
+        })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,28 @@ use serde::{Deserialize, Serialize};
 pub mod openid {
     use super::*;
 
+    /// OpenID Metadata Urls
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+    pub struct MetadataUrls {
+        /// The OpenID connect auth URL.
+        pub auth: String,
+        /// The OpenID token auth URL.
+        pub token: String,
+        /// The OpenID user info auth URL.
+        pub user_info: String,
+        /// The OpenID jwks url.
+        pub jwks: String,
+    }
+    /// OpenID Metadata Source
+    /// Defines how to fetch the openid metadata (auth_url, token_url, user_info_url, jwks_url)
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+    pub enum MetadataSource {
+        #[default]
+        /// Using the discovery information living at `issuer_url/.well_known/openid-configuration` https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
+        Discovery,
+        /// Manual configuration
+        Manual(MetadataUrls),
+    }
     /// OpenID Connect client configuration
     ///
     /// ## Non-exhaustive
@@ -19,21 +41,13 @@ pub mod openid {
         pub client_id: String,
         /// The OpenID connect issuer URL.
         pub issuer_url: String,
-        /// If the following urls are set, the client will be built from them
-        /// The OpenID connect auth URL.
-        pub auth_url: Option<String>,
-        /// The OpenID token auth URL.
-        pub token_url: Option<String>,
-        /// The OpenID user info auth URL.
-        pub user_info_url: Option<String>,
-        /// The OpenID jwks url.
-        pub jwks_url: Option<String>,
+        /// How to fetch the metadata
+        pub metadata_source: MetadataSource,
         /// An override for the end session URL.
         pub end_session_url: Option<String>,
         /// The URL to navigate to after the logout has been completed.
         pub after_logout_url: Option<String>,
         /// The name of the query parameter for the post logout redirect.
-        ///
         /// The defaults to `post_logout_redirect_uri` for OpenID RP initiated logout.
         /// However, e.g. older Keycloak instances, require this to be `redirect_uri`.
         pub post_logout_redirect_name: Option<String>,
@@ -52,10 +66,7 @@ pub mod openid {
                 client_id: client_id.into(),
                 issuer_url: issuer_url.into(),
 
-                auth_url: None,
-                token_url: None,
-                user_info_url: None,
-                jwks_url: None,
+                metadata_source: MetadataSource::Discovery,
 
                 end_session_url: None,
                 after_logout_url: None,
@@ -124,25 +135,9 @@ pub mod openid {
             self
         }
 
-        /// Set the provider auth url, skip metadata
-        pub fn with_auth_url(mut self, auth_url: impl Into<String>) -> Self {
-            self.auth_url = Some(auth_url.into());
-            self
-        }
-
-        /// Set the provider token url, skip metadata
-        pub fn with_token_url(mut self, token_url: impl Into<String>) -> Self {
-            self.token_url = Some(token_url.into());
-            self
-        }
-        /// Set the provider user_info url, skip metadata
-        pub fn with_user_info_url(mut self, user_info_url: impl Into<String>) -> Self {
-            self.user_info_url = Some(user_info_url.into());
-            self
-        }
-        /// Set the provider jwks url, skip metadata
-        pub fn with_jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
-            self.jwks_url = Some(jwks_url.into());
+        /// Set the metadata source
+        pub fn with_metadata_source(mut self, metadata_source: MetadataSource) -> Self {
+            self.metadata_source = metadata_source;
             self
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,15 @@ pub mod openid {
         pub client_id: String,
         /// The OpenID connect issuer URL.
         pub issuer_url: String,
+        /// If the following urls are set, the client will be built from them
+        /// The OpenID connect auth URL.
+        pub auth_url: Option<String>,
+        /// The OpenID token auth URL.
+        pub token_url: Option<String>,
+        /// The OpenID user info auth URL.
+        pub user_info_url: Option<String>,
+        /// The OpenID jwks url.
+        pub jwks_url: Option<String>,
         /// An override for the end session URL.
         pub end_session_url: Option<String>,
         /// The URL to navigate to after the logout has been completed.
@@ -42,6 +51,11 @@ pub mod openid {
             Self {
                 client_id: client_id.into(),
                 issuer_url: issuer_url.into(),
+
+                auth_url: None,
+                token_url: None,
+                user_info_url: None,
+                jwks_url: None,
 
                 end_session_url: None,
                 after_logout_url: None,
@@ -107,6 +121,28 @@ pub mod openid {
         /// Specifies whether the issuer claim must match the expected issuer URL for the provider.
         pub fn with_require_issuer_match(mut self, require_issuer_match: bool) -> Self {
             self.require_issuer_match = require_issuer_match;
+            self
+        }
+
+        /// Set the provider auth url, skip metadata
+        pub fn with_auth_url(mut self, auth_url: impl Into<String>) -> Self {
+            self.auth_url = Some(auth_url.into());
+            self
+        }
+
+        /// Set the provider token url, skip metadata
+        pub fn with_token_url(mut self, token_url: impl Into<String>) -> Self {
+            self.token_url = Some(token_url.into());
+            self
+        }
+        /// Set the provider user_info url, skip metadata
+        pub fn with_user_info_url(mut self, user_info_url: impl Into<String>) -> Self {
+            self.user_info_url = Some(user_info_url.into());
+            self
+        }
+        /// Set the provider jwks url, skip metadata
+        pub fn with_jwks_url(mut self, jwks_url: impl Into<String>) -> Self {
+            self.jwks_url = Some(jwks_url.into());
             self
         }
     }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -18,6 +18,8 @@ pub type Claims = openidconnect::IdTokenClaims<
 pub struct Authentication {
     /// The access token
     pub access_token: String,
+    /// The id token
+    pub id_token: Option<String>,
     /// An optional refresh token
     pub refresh_token: Option<String>,
     /// OpenID claims
@@ -59,6 +61,12 @@ impl OAuth2Context {
     /// Get the access token, if the context is [`OAuth2Context::Authenticated`]
     pub fn access_token(&self) -> Option<&str> {
         self.authentication().map(|auth| auth.access_token.as_str())
+    }
+
+    /// Get the id token, if the context is [`OAuth2Context::Authenticated`]
+    pub fn id_token(&self) -> Option<&str> {
+        self.authentication()
+            .and_then(|auth| auth.id_token.as_deref())
     }
 
     /// Get the claims, if the context is [`OAuth2Context::Authenticated`]

--- a/yew-oauth2-example/src/components/use_auth.rs
+++ b/yew-oauth2-example/src/components/use_auth.rs
@@ -18,6 +18,7 @@ fn dummy() -> Authentication {
     Authentication {
         access_token: "".to_string(),
         refresh_token: None,
+        id_token: None,
         #[cfg(feature = "openid")]
         claims: None,
         expires: None,

--- a/yew-oauth2-redirect-example/src/components/use_auth.rs
+++ b/yew-oauth2-redirect-example/src/components/use_auth.rs
@@ -17,6 +17,7 @@ impl UseAuthenticationProperties for Props {
 fn dummy() -> Authentication {
     Authentication {
         access_token: "".to_string(),
+        id_token: None,
         refresh_token: None,
         #[cfg(feature = "openid")]
         claims: None,


### PR DESCRIPTION
This allows for the client to be configured without using the discovery document